### PR TITLE
Fix: Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ var config = {};
 var server = new hapi.Server(config);
 server.register([Vision, Inert, Lout], (err) => {
 
-    if (err)
+    if (err) {
         console.error('Failed loading plugins');
         process.exit(1);
+    }
 
     server.start(() => {
 


### PR DESCRIPTION
Missing curly braces in error handling in one example